### PR TITLE
fixing integer NA exception

### DIFF
--- a/pandas_access/__init__.py
+++ b/pandas_access/__init__.py
@@ -34,7 +34,8 @@ def _extract_dtype(data_type):
     if data_type.startswith('double'):
         return np.float_
     elif data_type.startswith('long'):
-        return np.int_
+        #return np.int_
+        return 'Int64'
     else:
         return None
 


### PR DESCRIPTION
Pandas default integer field produces an exception if any of the data values is NA. 
This pull request fixes this issue: see https://stackoverflow.com/questions/11548005/numpy-or-pandas-keeping-array-type-as-integer-while-having-a-nan-value